### PR TITLE
typo fix for auto-allocate-uids

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Differing from the current official [Nix](https://github.com/NixOS/nix) installe
   + `bash-prompt-prefix` is set
   + `auto-optimise-store` is set to `true`
   * `extra-nix-path` is set to `nixpkgs=flake:nixpkgs`
-  * `auto-uid-allocation` is set to `true`.
+  * `auto-allocate-uids` is set to `true`.
 * an installation receipt (for uninstalling) is stored at `/nix/receipt.json` as well as a copy of the install binary at `/nix/nix-installer`
 * `nix-channel --update` is not run, `~/.nix-channels` is not provisioned
 * `NIX_SSL_CERT_FILE` is set in the various shell profiles if the `ssl-cert-file` argument is used.


### PR DESCRIPTION


##### Description

The config option `auto-uid-allocation` does exist even if the experimental feature `auto-allocate-uids` is enabled.

##### Checklist

- [X] Formatted with `cargo fmt`
- [X] Built with `nix build`
- [X] Ran flake checks with `nix flake check`
- [X] Added or updated relevant tests (leave unchecked if not applicable)
- [X] Added or updated relevant documentation (leave unchecked if not applicable)
- [X] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
